### PR TITLE
feat: add query mappers + small boilerplate for rendering

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,6 +5,5 @@
 	"semi": false,
 	"singleQuote": true,
 	"jsxSingleQuote": true,
-	"arrowParens": "always",
 	"bracketSameLine": false
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import './App.css'
 import ApolloClient, { InMemoryCache } from 'apollo-boost'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { FetchCountries } from './views/Countries'
-import { QueryBy } from './queries/interfaces'
+import { QueryBy, SortBy } from './queries/interfaces'
 
 const client = new ApolloClient({
 	uri: 'https://countries.trevorblades.com',
@@ -12,15 +12,28 @@ const client = new ApolloClient({
 
 const App = () => {
 	const [queryType, setQueryType] = useState<QueryBy>('continent')
+	const [sortType, setSortType] = useState<SortBy>('name')
+
+	const handleQueryType = (query: QueryBy) => {
+		setQueryType(query)
+	}
+
+	const handleSortType = (sort: SortBy) => {
+		setSortType(
+			sort === sortType && sortType.charAt(0) !== '-'
+				? (('-' + sort) as SortBy)
+				: sort
+		)
+	}
 
 	return (
 		<ApolloProvider client={client}>
 			<div>
-				<h2>
-					<button onClick={() => setQueryType('continent')}>Continents</button>
-					<button onClick={() => setQueryType('language')}>Languages</button>
-					<FetchCountries query={queryType} />
-				</h2>
+				<button onClick={() => handleQueryType('continent')}>Continents</button>
+				<button onClick={() => handleQueryType('language')}>Languages</button>
+				<button onClick={() => handleSortType('name')}>Name</button>
+				<button onClick={() => handleSortType('count')}>Count</button>
+				<FetchCountries type={queryType} sort={sortType} />
 			</div>
 		</ApolloProvider>
 	)

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -1,0 +1,23 @@
+import { ByContinent, ByLanguage } from '../queries/interfaces'
+import { Continent, Languages } from '../queries/interfaces'
+
+interface DataMapProps {
+	query: string
+}
+
+export interface ContinentMapProps extends DataMapProps {
+	data: ByContinent
+}
+
+export interface LanguageMapProps extends DataMapProps {
+	data: ByLanguage
+}
+
+export type ContinentMapper = ({
+	data,
+	query
+}: ContinentMapProps) => Continent[]
+
+export type LanguageMapper = ({ data, query }: LanguageMapProps) => Languages[]
+
+export type NormalizedOutput = Continent[] | Languages[]

--- a/src/helpers/mappers.ts
+++ b/src/helpers/mappers.ts
@@ -1,0 +1,44 @@
+import { ContinentMapper, LanguageMapper } from './interfaces'
+
+export const countriesByContinent: ContinentMapper = ({ data, query }) => {
+	let { continents } = data
+
+	if (query) {
+		continents = continents
+			.map((continent) => {
+				return {
+					...continent,
+					countries: continent.countries.filter((country) =>
+						country.name.toLowerCase().includes(query.toLowerCase())
+					)
+				}
+			})
+			.filter((continent) => continent.countries.length)
+	}
+
+	return continents
+}
+
+export const countriesByLanguage: LanguageMapper = ({ data, query }) => {
+	let { countries, languages } = data
+
+	if (query) {
+		countries = data.countries.filter((country) =>
+			country.name.toLowerCase().includes(query.toLowerCase())
+		)
+		languages = languages.filter(
+			(language) =>
+				countries.filter((country) =>
+					country.languages.map((e) => e.name).includes(language.name)
+				).length
+		)
+	}
+	return languages.map((language) => {
+		return {
+			...language,
+			countries: data.countries.filter((country) =>
+				country.languages.map((e) => e.name).includes(language.name)
+			)
+		}
+	})
+}

--- a/src/queries/interfaces.ts
+++ b/src/queries/interfaces.ts
@@ -1,37 +1,46 @@
-interface Language {
+export interface Language {
 	name: 'string'
 	code?: 'string'
 }
 
-interface Country {
+export interface Continent {
+	name: string
+	code: string
+	countries: Country[]
+}
+
+export interface Country {
 	name: string
 	code: string
 	native: string
 	capital: string
 	emoji: string
-	languages: Array<Language>
+	languages: Language[]
 	continent?: { name: string }
 }
 
-interface Continent {
-	name: string
-	code: string
-	countries: Array<Country>
-}
-
 export interface ByContinent {
-	continents: Array<Continent>
+	continents: Continent[]
 }
 
 export interface ByLanguage {
-	countries: Array<Country>
-	languages: Array<Language>
+	countries: Country[]
+	languages: Language[]
 }
 
 export type QueryBy = 'continent' | 'language'
+export type SortBy = 'name' | 'count' | '-name' | '-count'
 
 export interface FetchProps {
-	query?: QueryBy
+	type: QueryBy
+	sort: SortBy
+	query?: string
 }
 
 export type FetchAction = ({ query }: FetchProps) => JSX.Element | null
+
+export interface Languages extends Language {
+	countries: Country[]
+}
+
+export type NormalizedOutput = Continent[] | Languages[]

--- a/src/views/Countries.tsx
+++ b/src/views/Countries.tsx
@@ -7,21 +7,44 @@ import {
 	FetchAction
 } from '../queries/interfaces'
 import { Either } from '../queries/types'
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import { countriesByContinent, countriesByLanguage } from '../helpers/mappers'
+import {
+	ContinentMapProps,
+	LanguageMapProps,
+	NormalizedOutput
+} from '../helpers/interfaces'
 
-export const FetchCountries: FetchAction = ({ query }: FetchProps) => {
+export const FetchCountries: FetchAction = ({ type, query }: FetchProps) => {
 	const { data, loading, error } = useQuery<Either<ByContinent, ByLanguage>>(
-		query === 'continent' ? COUNTRIES_BY_CONTINENT : COUNTRIES_AND_LANGUAGES
+		type === 'continent' ? COUNTRIES_BY_CONTINENT : COUNTRIES_AND_LANGUAGES
 	)
-	// console.log(data)
+
+	const [currentData, setCurrentData] = useState<NormalizedOutput>([])
+
+	useEffect(() => {
+		if (!loading && data) {
+			setCurrentData(
+				type === 'continent'
+					? countriesByContinent({ data, query } as ContinentMapProps)
+					: countriesByLanguage({ data, query } as LanguageMapProps)
+			)
+		}
+	}, [data, type])
 
 	if (error) return <div>error</div>
 	else if (loading) return <div>loading</div>
-	else if (data)
+	else if (currentData)
 		return (
 			<div>
-				{data?.countries?.length}
-				{data?.continents?.length}
+				{currentData.map((e) => (
+					<div key={e.code}>
+						<h3>{e.name}</h3>
+						<small>
+							{e.countries?.map((country) => country.name).join(', ')}
+						</small>
+					</div>
+				))}
 			</div>
 		)
 	else return null


### PR DESCRIPTION
Added query mappers.
Tested around with different mapping methods and managed to get rendering times down to:

- 100ms for continents mapper
- 300ms for languages mapper

I'll try to find a better method later.

